### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ansible-pecan
 =============
 A playbook to deploy Pecan applications. It is initially a bit opinionated
-choosing nginx for the web server and `circus <https://circus.readthedocs.org/en/latest/>`_
+choosing nginx for the web server and `circus <https://circus.readthedocs.io/en/latest/>`_
 for managing the services.
 
 Currently supported distributions:


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
